### PR TITLE
Cleanup Terraform resources (stage 3)

### DIFF
--- a/.github/actions/terraform/entrypoint.sh
+++ b/.github/actions/terraform/entrypoint.sh
@@ -58,7 +58,13 @@ elif [ "${TF_STAGE}" = "stage2" ]; then
     -var="django_secret_key_prod=${DJANGO_SECRET_KEY_PROD}" \
     -var="arm_client_id=${ARM_CLIENT_ID}" \
     -var="arm_client_secret=${ARM_CLIENT_SECRET}"
+elif [ "${TF_STAGE}" = "stage3" ]; then
+  terraform -chdir="${TF_STAGE}" init \
+    -backend-config="key=${STATE_KEY}.tfstate" \
+    -backend-config="use_azuread_auth=true"
+  terraform -chdir="${TF_STAGE}" plan -out="${PLAN_FILE}"
+  terraform -chdir="${TF_STAGE}" apply -auto-approve "${PLAN_FILE}"
 else
-  echo "Unsupported tf_stage '${TF_STAGE}'. Supported values: stage1, stage2"
+  echo "Unsupported tf_stage '${TF_STAGE}'. Supported values: stage1, stage2, stage3"
   exit 1
 fi

--- a/.github/workflows/build-and-curl.yml
+++ b/.github/workflows/build-and-curl.yml
@@ -164,3 +164,22 @@ jobs:
           echo "Using DNS prefix: ${PREFIX}"
           sleep 50
           curl -fsS "http://${PREFIX}.centralus.azurecontainer.io:8000"
+
+  tf-stage-three-destroy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.run_terraform == 'true' && always() }}
+    needs:
+      - preval
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Run custom Terraform action (stage3 destroy)
+        uses: ./.github/actions/terraform
+        with:
+          arm_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          arm_tenant_id: ${{ secrets.ARM_TENANT_ID }}
+          arm_client_id: ${{ secrets.ARM_CLIENT_ID }}
+          arm_client_secret: ${{ secrets.ARM_CLIENT_SECRET }}
+          state_key: ${{ github.event.inputs.state_key }}
+          tf_stage: stage3

--- a/stage3/main.tf
+++ b/stage3/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.68.0"
+    }
+  }
+
+  # Stage 3 uses the same remote backend as stage 1/2, but intentionally defines
+  # no resources so Terraform will destroy everything managed in the state.
+  backend "azurerm" {
+    resource_group_name  = "rg-acmp-final"
+    storage_account_name = "acmp2400storageaccount"
+    container_name       = "big-tf-state-acmp2400"
+    use_azuread_auth     = true
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+


### PR DESCRIPTION
Add stage 3 Terraform configuration and extend the Terraform action + workflow so resources are destroyed at the end of the deployment pipeline, even if the reachability check fails.